### PR TITLE
Add LoadImageFromBytes and CompositionImageLoader.XamlExtensions

### DIFF
--- a/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.csproj
+++ b/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.csproj
@@ -128,4 +128,16 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <!-- MSBuildTasks nuget is currently hosed for UWP
+  <PropertyGroup>
+    <MSBuildCommunityTasksPath>$(SolutionDir)\.build</MSBuildCommunityTasksPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" />
+  -->
+  <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release'">
+    <!-- Only download a new copy of nuget.exe if we don't have a copy available -->
+    <!--<WebDownload Condition="!Exists('nuget.exe')" Filename="nuget.exe" FileUri="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" /> -->
+    <Exec Command="nuget pack CompositionImageLoader.XamlExtensions.csproj -IncludeReferencedProjects -Prop Configuration=Release">
+    </Exec>
+  </Target>
 </Project>

--- a/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.csproj
+++ b/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.csproj
@@ -1,0 +1,131 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A5526B4B-224F-407F-A3FA-746D1126B4B0}</ProjectGuid>
+    <OutputType>winmdobj</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Robmikh.Util.CompositionImageLoader.XamlExtensions</RootNamespace>
+    <AssemblyName>CompositionImageLoader.XamlExtensions</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ImageLoaderExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CompositionImageLoader\CompositionImageLoader.csproj">
+      <Project>{ad0e6e4b-452b-47c3-94ac-c7bc0068c61b}</Project>
+      <Name>CompositionImageLoader</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.csproj
+++ b/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.csproj
@@ -111,12 +111,6 @@
     <Compile Include="ImageLoaderExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CompositionImageLoader\CompositionImageLoader.csproj">
-      <Project>{ad0e6e4b-452b-47c3-94ac-c7bc0068c61b}</Project>
-      <Name>CompositionImageLoader</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.nuspec
+++ b/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>https://github.com/robmikh/compositionimageloader</projectUrl>
+    <iconUrl>http://robmikh.com/compimageloader.png</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Initial release.</releaseNotes>
+    <copyright>Copyright 2016</copyright>
+	<dependencies>
+		<dependency id="" version="" />
+        <dependency id="Win2D.uwp" version="1.16.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.nuspec
+++ b/CompositionImageLoader.XamlExtensions/CompositionImageLoader.XamlExtensions.nuspec
@@ -14,7 +14,7 @@
     <releaseNotes>Initial release.</releaseNotes>
     <copyright>Copyright 2016</copyright>
 	<dependencies>
-		<dependency id="" version="" />
+		<dependency id="Robmikh.Util.CompositionImageLoader" version="0.4.0-alpha" />
         <dependency id="Win2D.uwp" version="1.16.0" />
     </dependencies>
   </metadata>

--- a/CompositionImageLoader.XamlExtensions/ImageLoaderExtensions.cs
+++ b/CompositionImageLoader.XamlExtensions/ImageLoaderExtensions.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.UI.Composition;
+using Robmikh.Util.CompositionImageLoader;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Graphics.DirectX;
+using Windows.UI.Composition;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Robmikh.Util.CompositionImageLoader.XamlExtensions
+{
+    public static class ImageLoaderExtensions
+    {
+        public static IAsyncOperation<CompositionDrawingSurface> LoadImageFromUIElementAsync(this IImageLoader imageLoader, UIElement element)
+        {
+            return LoadImageFromUIElementAsyncWorker(imageLoader, element, Size.Empty).AsAsyncOperation<CompositionDrawingSurface>();
+        }
+
+        public static IAsyncOperation<CompositionDrawingSurface> LoadImageFromUIElementAsync(this IImageLoader imageLoader, UIElement element, Size size)
+        {
+            return LoadImageFromUIElementAsyncWorker(imageLoader, element, size).AsAsyncOperation<CompositionDrawingSurface>();
+        }
+
+        private static async Task<CompositionDrawingSurface> LoadImageFromUIElementAsyncWorker(IImageLoader imageLoader, UIElement element, Size size)
+        {
+            return await DrawUIElement(imageLoader, element, size);
+        }
+
+        private static async Task<CompositionDrawingSurface> DrawUIElement(IImageLoader imageLoader, UIElement element, Size size)
+        {
+            var xamlBitmap = new RenderTargetBitmap();
+            await xamlBitmap.RenderAsync(element);
+            var pixels = await xamlBitmap.GetPixelsAsync();
+
+            return imageLoader.LoadImageFromBytes(pixels.ToArray(), xamlBitmap.PixelWidth, xamlBitmap.PixelHeight, size);
+        }
+    }
+}

--- a/CompositionImageLoader.XamlExtensions/ImageLoaderExtensions.cs
+++ b/CompositionImageLoader.XamlExtensions/ImageLoaderExtensions.cs
@@ -29,11 +29,6 @@ namespace Robmikh.Util.CompositionImageLoader.XamlExtensions
 
         private static async Task<CompositionDrawingSurface> LoadImageFromUIElementAsyncWorker(IImageLoader imageLoader, UIElement element, Size size)
         {
-            return await DrawUIElement(imageLoader, element, size);
-        }
-
-        private static async Task<CompositionDrawingSurface> DrawUIElement(IImageLoader imageLoader, UIElement element, Size size)
-        {
             var xamlBitmap = new RenderTargetBitmap();
             await xamlBitmap.RenderAsync(element);
             var pixels = await xamlBitmap.GetPixelsAsync();

--- a/CompositionImageLoader.XamlExtensions/Properties/AssemblyInfo.cs
+++ b/CompositionImageLoader.XamlExtensions/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("CompositionImageLoader")]
-[assembly: AssemblyDescription("An image loader to use with the Windows.UI.Composition api based on Win2D and written with C#.")]
+[assembly: AssemblyTitle("CompositionImageLoader.XamlExtensions")]
+[assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Robert Mikhayelyan")]
-[assembly: AssemblyProduct("CompositionImageLoader")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CompositionImageLoader.XamlExtensions")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -24,7 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0")]
-[assembly: AssemblyInformationalVersion("0.4.0-alpha")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: ComVisible(false)]

--- a/CompositionImageLoader.XamlExtensions/Properties/AssemblyInfo.cs
+++ b/CompositionImageLoader.XamlExtensions/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CompositionImageLoader.XamlExtensions")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("XAML related extensions for CompositionImageLoader.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Robert Mikhayelyan")]
 [assembly: AssemblyProduct("CompositionImageLoader.XamlExtensions")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright �  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -24,6 +24,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.1.0")]
+[assembly: AssemblyInformationalVersion("0.1.0-alpha")]
+[assembly: AssemblyFileVersion("0.1.0.0")]
 [assembly: ComVisible(false)]

--- a/CompositionImageLoader.XamlExtensions/project.json
+++ b/CompositionImageLoader.XamlExtensions/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "dependencies": {
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+  },
+  "frameworks": {
+    "uap10.0": {}
+  },
+  "runtimes": {
+    "win10-arm": {},
+    "win10-arm-aot": {},
+    "win10-x86": {},
+    "win10-x86-aot": {},
+    "win10-x64": {},
+    "win10-x64-aot": {}
+  }
+}

--- a/CompositionImageLoader.XamlExtensions/project.json
+++ b/CompositionImageLoader.XamlExtensions/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Robmikh.Util.CompositionImageLoader": "0.4.0-alpha"
   },
   "frameworks": {
     "uap10.0": {}

--- a/CompositionImageLoader.sln
+++ b/CompositionImageLoader.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompositionImageLoader", "CompositionImageLoader\CompositionImageLoader.csproj", "{AD0E6E4B-452B-47C3-94AC-C7BC0068C61B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompositionImageLoader.XamlExtensions", "CompositionImageLoader.XamlExtensions\CompositionImageLoader.XamlExtensions.csproj", "{A5526B4B-224F-407F-A3FA-746D1126B4B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,22 @@ Global
 		{AD0E6E4B-452B-47C3-94AC-C7BC0068C61B}.Release|x64.Build.0 = Release|x64
 		{AD0E6E4B-452B-47C3-94AC-C7BC0068C61B}.Release|x86.ActiveCfg = Release|x86
 		{AD0E6E4B-452B-47C3-94AC-C7BC0068C61B}.Release|x86.Build.0 = Release|x86
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|ARM.ActiveCfg = Debug|ARM
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|ARM.Build.0 = Debug|ARM
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|x64.ActiveCfg = Debug|x64
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|x64.Build.0 = Debug|x64
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|x86.ActiveCfg = Debug|x86
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Debug|x86.Build.0 = Debug|x86
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|ARM.ActiveCfg = Release|ARM
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|ARM.Build.0 = Release|ARM
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|x64.ActiveCfg = Release|x64
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|x64.Build.0 = Release|x64
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|x86.ActiveCfg = Release|x86
+		{A5526B4B-224F-407F-A3FA-746D1126B4B0}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request adds LoadImageFromBytes to CompositionImageLoader, as well as makes some refactoring to make things nicer.

Additionally, CompositionImageLoader.XamlExtensions has been added to the solution. Currently this adds two overloads of LoadImageFromUIElementAsync. Loading form a UIElement is powered by RenderTargetBitmap and LoadImageFromBytes.
